### PR TITLE
RegNum Change

### DIFF
--- a/Journey.java
+++ b/Journey.java
@@ -18,7 +18,16 @@ public class Journey implements Comparable<Journey>
      */
     public Journey(String regNum, String driverName, String destName, double dist, int passNum) throws ImpossibleDistException, WrongPassException
     {   
-        this.regNum =regNum.trim();
+    	try {
+    		int regTest = Integer.parseInt(regNum.substring(3, regNum.length()));
+    		if (regNum.substring(0,3).contains("AFR") && regTest != 0){
+    			this.regNum =regNum.trim();
+    		} else {
+    			System.err.println("Improper Registration Format");
+    		}
+    	} catch (NumberFormatException e){
+    		System.err.println("Improper Registration Format: No Numbers");
+    	}
         this.driverName = driverName.trim();
         this.destName = destName.trim();
         if (dist > 0) {
@@ -98,9 +107,7 @@ public class Journey implements Comparable<Journey>
             return regNum.equals(otherJourney.getReg()) &&
             		driverName.equals(otherJourney.getDriver()) &&
             		destName.equals(otherJourney.getDest()) &&
-            		dist == (otherJourney.getDist()) &&
-            		passNum == (otherJourney.getPass())&&
-            		cost == (otherJourney.getCost());
+            		passNum == (otherJourney.getPass());
         }
         else {
             return false;

--- a/taxi_details.txt
+++ b/taxi_details.txt
@@ -1,20 +1,21 @@
-AFR22 HCD; Farrow Monica
-AFR13 BBF; Browning David
-AFR09 KWO; Anderson John
-AFR67 PNW; Read Helen
-AFR46 KIM; White Emma
-AFR80 OFH; Green Kate  
-AFR66 AHW; Black Chris 
-AFR16 ZNW; Jane Radcliffe
-AFR11 KKO; Grey Ruth  
-AFR22 AZM; Guy Kahane
-AFR83 DMS; Hannah Wilkinson
-AFR34 UPM; Henry Shue
-AFR75 KKW; India Masaki
-AFR26 RDM; Mark Singh
-AFR37 HAH; Derek Persson
-AFR78 KJM; James Griffin
-AFR96 LTK; Janet Richards
-AFR50 RNK; Roger Douglas
-AFR14 DMB; Thomas Scanlon
-AFR32 UEC; Tim Toby
+AFR22; Farrow Monica
+AFR13; Browning David
+AFR09; Anderson John
+AFR67; Read Helen
+AFR46; White Emma
+AFR80; Green Kate  
+AFR66; Black Chris 
+AFR16; Jane Radcliffe
+AFR11; Grey Ruth  
+AFR22; Guy Kahane
+AFR83; Hannah Wilkinson
+AFR34; Henry Shue
+AFR75; India Masaki
+AFR26; Mark Singh
+AFR37; Derek Persson
+AFR78; James Griffin
+AFR96; Janet Richards
+AFR50; Roger Douglas
+AFR14; Thomas Scanlon
+AFR32; Tim Toby
+


### PR DESCRIPTION
I propose that we change RegNum to have a different format, namely 
AFR(Numbers) 
Instead of
AFR(Numbers) (String)
This way, my journey class is effectively able to test RegNum using a try/catch block and see if its format is up to snuff.  I could probably make journey class check the format we have now, but it would be more difficult, potentially needlessly so.  What do you guys think?